### PR TITLE
Bot support users can add a custom marriage time

### DIFF
--- a/cogs/server_specific.py
+++ b/cogs/server_specific.py
@@ -262,7 +262,7 @@ class ServerSpecific(utils.Cog):
         async with self.bot.redis() as re:
             await re.publish('TreeMemberUpdate', usera_tree.to_json())
             await re.publish('TreeMemberUpdate', userb_tree.to_json())
-            
+
     @utils.command(add_slash_command=False, aliases=['addtime', 'marriagetime', 'marrytime'])
     @localutils.checks.is_server_specific_bot_moderator()
     @commands.bot_has_permissions(send_messages=True)
@@ -270,32 +270,33 @@ class ServerSpecific(utils.Cog):
         """
         Adds a custom timestamp to an existing marriage. Timestamps are formatted by Day/Month and an optional Year (the year defaults to the current year)
         """
-        
+
         # Correct user params
         if userb is None:
             usera, userb = ctx.author.id, usera
         if usera == userb:
             return await ctx.send("You aren't married to yourself.")
-        
+
         # Correct time param
         try:
             dt_time = localutils.fix_time_string(new_time)
         except Exception:
             return await ctx.send("I ran into an error getting the time. Make sure your time is written as 'day/month', and that the day and month exist.")
+
         # Make sure we're not in the future
         if dt_time > dt.utcnow():
             return await ctx.send("That date is in the future - make sure you're using the UTC timezone")
-        
+
         # Get user variables
         family_guild_id = localutils.get_family_guild_id(ctx)
         usera_tree, userb_tree = localutils.FamilyTreeMember.get_multiple(usera, userb, guild_id=family_guild_id)
         usera_name = await localutils.DiscordNameManager.fetch_name_by_id(self.bot, usera_tree.id)
         userb_name = await localutils.DiscordNameManager.fetch_name_by_id(self.bot, userb_tree.id)
-        
+
         # See if they are each other's partners
-        if usera_tree._partner != user_b:
+        if usera_tree._partner != userb:
             return await ctx.send(f"**{usera_name}** and **{userb_name}** are not married to each other.", allowed_mentions=discord.AllowedMentions.none())
-        
+
         # Update database
         async with self.bot.database() as db:
             try:
@@ -307,7 +308,7 @@ class ServerSpecific(utils.Cog):
                 await db.commit_transaction()
             except asyncpg.UniqueViolationError:
                 return await ctx.send("I ran into an error saving your family data.")
-            
+
         await ctx.send(f"Set **{usera_name}** and **{userb_name}** marriage time to {new_time}.", allowed_mentions=discord.AllowedMentions.none())
 
     @utils.command(add_slash_command=False)

--- a/cogs/server_specific.py
+++ b/cogs/server_specific.py
@@ -262,6 +262,53 @@ class ServerSpecific(utils.Cog):
         async with self.bot.redis() as re:
             await re.publish('TreeMemberUpdate', usera_tree.to_json())
             await re.publish('TreeMemberUpdate', userb_tree.to_json())
+            
+    @utils.command(add_slash_command=False, aliases=['addtime', 'marriagetime', 'marrytime'])
+    @localutils.checks.is_server_specific_bot_moderator()
+    @commands.bot_has_permissions(send_messages=True)
+    async def addmarriagetime(self, ctx:utils.Context, usera:utils.converters.UserID, userb:utils.converters.UserID, new_time:str):
+        """
+        Adds a custom timestamp to an existing marriage. Timestamps are formatted by Day/Month and an optional Year (the year defaults to the current year)
+        """
+        
+        # Correct user params
+        if userb is None:
+            usera, userb = ctx.author.id, usera
+        if usera == userb:
+            return await ctx.send("You aren't married to yourself.")
+        
+        # Correct time param
+        try:
+            dt_time = localutils.fix_time_string(new_time)
+        except Exception:
+            return await ctx.send("I ran into an error getting the time. Make sure your time is written as 'day/month', and that the day and month exist.")
+        # Make sure we're not in the future
+        if dt_time > dt.utcnow():
+            return await ctx.send("That date is in the future - make sure you're using the UTC timezone")
+        
+        # Get user variables
+        family_guild_id = localutils.get_family_guild_id(ctx)
+        usera_tree, userb_tree = localutils.FamilyTreeMember.get_multiple(usera, userb, guild_id=family_guild_id)
+        usera_name = await localutils.DiscordNameManager.fetch_name_by_id(self.bot, usera_tree.id)
+        userb_name = await localutils.DiscordNameManager.fetch_name_by_id(self.bot, userb_tree.id)
+        
+        # See if they are each other's partners
+        if usera_tree._partner != user_b:
+            return await ctx.send(f"**{usera_name}** and **{userb_name}** are not married to each other.", allowed_mentions=discord.AllowedMentions.none())
+        
+        # Update database
+        async with self.bot.database() as db:
+            try:
+                await db.start_transaction()
+                await db(
+                    "UPDATE marriages SET timestamp = $4 WHERE ((user_id = $1 AND partner_id = $2) OR (partner_id = $1 AND user_id = $2)) AND guild_id = $3",
+                    usera_tree.id, userb_tree.id, family_guild_id, dt_time,
+                )
+                await db.commit_transaction()
+            except asyncpg.UniqueViolationError:
+                return await ctx.send("I ran into an error saving your family data.")
+            
+        await ctx.send(f"Set **{usera_name}** and **{userb_name}** marriage time to {new_time}.", allowed_mentions=discord.AllowedMentions.none())
 
     @utils.command(add_slash_command=False)
     @localutils.checks.is_server_specific_bot_moderator()

--- a/cogs/utils/__init__.py
+++ b/cogs/utils/__init__.py
@@ -7,6 +7,7 @@ from cogs.utils.family_tree.family_tree_member import FamilyTreeMember
 from cogs.utils.family_tree.relationship_string_simplifier import RelationshipStringSimplifier
 from cogs.utils.discord_name_manager import DiscordNameManager
 from cogs.utils.perks_handler import get_marriagebot_perks, TIER_NONE, TIER_ONE, TIER_TWO, TIER_THREE, TIER_VOTER, MarriageBotPerks
+from cogs.utils.time_handler import fix_time_string
 
 
 def get_family_guild_id(ctx) -> int:

--- a/cogs/utils/time_handler.py
+++ b/cogs/utils/time_handler.py
@@ -1,18 +1,19 @@
-from datetime import datetime as dt
 import re
 
+from datetime import datetime as dt
 
-def fix_time_string(time_str:str):
-  """
-  Takes a string of Day/Month(/Year) and returns a tuple of (day, month, year/current year)
-  """
 
-  # Set up the Regex statement
-  time_match = re.search(r"^(?P<day>\d+)\/(?P<month>\d+)(\/(?P<year>\d+))?$", time_str)
-  
-  # Set up the variables
-  day = int(time_match.group("day"))
-  month = int(time_match.group("month"))
-  year = int(time_match.group("year") or dt.utcnow().year)
+def fix_time_string(time_str: str):
+    """
+    Takes a string of Day/Month(/Year) and returns a tuple of (day, month, year/current year)
+    """
 
-  return dt(year, month, day)
+    # Set up the Regex statement
+    time_match = re.search(r"^(?P<day>\d+)\/(?P<month>\d+)(\/(?P<year>\d+))?$", time_str)
+
+    # Set up the variables
+    day = int(time_match.group("day"))
+    month = int(time_match.group("month"))
+    year = int(time_match.group("year") or dt.utcnow().year)
+
+    return dt(year, month, day)

--- a/cogs/utils/time_handler.py
+++ b/cogs/utils/time_handler.py
@@ -9,7 +9,8 @@ def fix_time_string(time_str:str):
 
   # Set up the Regex statement
   time_match = re.search(r"^(?P<day>\d+)\/(?P<month>\d+)(\/(?P<year>\d+))?$", time_str)
-
+  
+  # Set up the variables
   day = int(time_match.group("day"))
   month = int(time_match.group("month"))
   year = int(time_match.group("year") or dt.utcnow().year)

--- a/cogs/utils/time_handler.py
+++ b/cogs/utils/time_handler.py
@@ -1,0 +1,17 @@
+from datetime import datetime as dt
+import re
+
+
+def fix_time_string(time_str:str):
+  """
+  Takes a string of Day/Month(/Year) and returns a tuple of (day, month, year/current year)
+  """
+
+  # Set up the Regex statement
+  time_match = re.search(r"^(?P<day>\d+)\/(?P<month>\d+)(\/(?P<year>\d+))?$", time_str)
+
+  day = int(time_match.group("day"))
+  month = int(time_match.group("month"))
+  year = int(time_match.group("year") or dt.utcnow().year)
+
+  return dt(year, month, day)


### PR DESCRIPTION
By running m!addmarriagetime <usera> <userb> <time>, that time will replace their marriage's start time. This will affect what is displayed in m!partner. 

Time: written as "day/month" with an optional year that defaults to the current year.