### PR TITLE
add `wreath` as an alias to `familytree`

### DIFF
--- a/cogs/information.py
+++ b/cogs/information.py
@@ -383,7 +383,7 @@ class Information(vbu.Cog):
         await vbu.embeddify(ctx, output, allowed_mentions=discord.AllowedMentions.none())
 
     @commands.command(
-        aliases=['familytree', 't'],
+        aliases=['familytree', 't', 'wreath'],
         application_command_meta=commands.ApplicationCommandMeta(
             options=[
                 discord.ApplicationCommandOption(
@@ -415,7 +415,7 @@ class Information(vbu.Cog):
                 raise
 
     @commands.command(
-        aliases=['st', 'stupidtree', 'fulltree', 'bt'],
+        aliases=['st', 'stupidtree', 'fulltree', 'bt', 'stupidwreath', 'bloodwreath'],
         application_command_meta=commands.ApplicationCommandMeta(
             options=[
                 discord.ApplicationCommandOption(


### PR DESCRIPTION
This was done at the request of `The Judgmental Plague`, see [here](https://discord.com/channels/208895639164026880/689189589776203861/994087095406690445)

I clarified, and they just wanted a alias. I don't know ~~many other~~ any bots that would need a `wreath` as a alias for `tree`, but since prefix-based commands are going to eventually be phased out, might as well make them happy in the mean time. /shrug