### PR TITLE
Fix guild_id string -> int conversion

### DIFF
--- a/cogs/bot_moderator.py
+++ b/cogs/bot_moderator.py
@@ -437,7 +437,7 @@ class BotModerator(vbu.Cog[utils.types.Bot]):
 
         if guild_id and not guild_id.isdigit():
             return await ctx.send("No guild found.")
-        await self.reset_family(ctx, int(guild_id) if isinstance(guild_id, int) else None)
+        await self.reset_family(ctx, int(guild_id) if isdigit(guild_id) else None)
 
 
     async def reset_family(

--- a/cogs/bot_moderator.py
+++ b/cogs/bot_moderator.py
@@ -437,7 +437,7 @@ class BotModerator(vbu.Cog[utils.types.Bot]):
 
         if guild_id and not guild_id.isdigit():
             return await ctx.send("No guild found.")
-        await self.reset_family(ctx, int(guild_id) if isdigit(guild_id) else None)
+        await self.reset_family(ctx, int(guild_id) if guild_id.isdigit() else None)
 
 
     async def reset_family(


### PR DESCRIPTION
We should probably be checking if the guild_id string is composed of digits before casting it to a string (rather than checking if it's... already an int)